### PR TITLE
Fix markdown lint issues in nvm/README.md (#36)

### DIFF
--- a/nvm/README.md
+++ b/nvm/README.md
@@ -1,19 +1,28 @@
 # Node Version Manager
 
 ## Step 1: Install developer tools
+
 From an SSH terminal, run:
-```
+
+```bash
 yum group install "Development Tools"
 ```
+
 ## Step 2: Install NVM
 
-First, install necessary prerequisites using [yum](../yum/) to verify that you have curl and/or wget installed. Make sure you [set your PATH](../troubleshooting/SETTING_PATH.md) to utilize the new open source technology.
+First, install necessary prerequisites using [yum](../yum/) to verify that you
+have curl and/or wget installed. Make sure you
+[set your PATH](../troubleshooting/SETTING_PATH.md) to utilize the new open
+source technology.
 
-Then, simply follow the installation steps on the [nvm project page](https://github.com/creationix/nvm/)
+Then, simply follow the installation steps on the
+[nvm project page](https://github.com/creationix/nvm/)
 
 ## Step 3: Configure your $HOME/.nvmrc file
+
 Create a file at `$HOME/.nvmrc`, with the following contents
-```
+
+```bash
 --dest-cpu=ppc64
 --without-snapshot
 --shared-openssl
@@ -21,15 +30,19 @@ Create a file at `$HOME/.nvmrc`, with the following contents
 ```
 
 ## Step 4: Set necessary environment variables
+
 Set the following environment variables:
-```
+
+```bash
 OBJECT_MODE=64
 CC=gcc
 CXX=g++
 ```
 
-Preferrably, set these in your `$HOME/.profile` and/or `$HOME/.bash_profile` (depending on your shell settings), by adding the following lines:
-```
+Preferrably, set these in your `$HOME/.profile` and/or `$HOME/.bash_profile`
+(depending on your shell settings), by adding the following lines:
+
+```bash
 OBJECT_MODE=64
 export OBJECT_MODE
 CC=gcc
@@ -38,8 +51,11 @@ CXX=g++
 export CXX
 ```
 
-## Step 5: Run nvm!
-NVM, like many open source commands, are best run from an SSH terminal. See the [nvm project page](https://github.com/creationix/nvm/) for example usages of the command. Some examples include:
+## Step 5: Run nvm
+
+NVM, like many open source commands, are best run from an SSH terminal. See the
+[nvm project page](https://github.com/creationix/nvm/) for example usages of the
+command. Some examples include:
 
 * `nvm install stable` : install the latest stable version
 * `nvm install --lts` : install the latest LTS release


### PR DESCRIPTION
Fixes #36 

Satisfying these markdownlint rules:
- **[MD022](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md022)** *blanks-around-headings/blanks-around-headers* - Headings should be surrounded by blank lines
- **[MD031](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md031)** *blanks-around-fences* - Fenced code blocks should be surrounded by blank lines
- **[MD013](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013)** *line-length* - Line length (limited to 80 chars)
- **[MD026](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md026)** *no-trailing-punctuation* - Trailing punctuation in heading (removed `!`)
- **[MD040](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md040)** *fenced-code-language* - Fenced code blocks should have a language specified (added `bash`)