### PR TITLE
Switch from recommonmark to MyST-Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # IBM i Open Source
 
 This repo will act as the authoritative documentation location for all things
@@ -22,23 +21,27 @@ documentation, please do one of the following:
 
 ## Contents
 
-- [Getting Started](yum/README.md)
-- [Troubleshooting](troubleshooting/README.md)
-- [Node.js](nodejs/README.md)
-- [Python](python/README.md)
-- [Setting up TLS](tls/README.md)
-- [ODBC](odbc/README.md)
-- [Java](java/README.md)
-- [Kafka](kafka/README.md)
-- [Camel](camel/README.md)
-- [Nginx](nginx.md)
-- [PostgreSQL](postgresql.md)
-- [Certbot (LetsEncrypt)](certbot.md)
-- [ACS Clone Repo Tool](acscloner/README.md)
-- [IBM Repos](yum/IBM_REPOS.md)
-- [Third Party Repos](yum/3RD_PARTY_REPOS.md)
-- [Porting Software to PASE](porting/README.md)
-- [Migrating from 5733-OPS](troubleshooting/5733OPS_MIGRATION.md)
+```{toctree}
+:maxdepth: 1
+
+Getting Started <yum/README.md>
+Troubleshooting <troubleshooting/README.md>
+Node.js <nodejs/README.md>
+Python <python/README.md>
+Setting up TLS <tls/README.md>
+ODBC <odbc/README.md>
+Java <java/README.md>
+Kafka <kafka/README.md>
+Camel <camel/README.md>
+Nginx <nginx.md>
+PostgreSQL <postgresql.md>
+Certbot (LetsEncrypt) <certbot.md>
+ACS Clone Repo Tool <acscloner/README.md>
+IBM Repos <yum/IBM_REPOS.md>
+Third Party Repos <yum/3RD_PARTY_REPOS.md>
+Porting Software to PASE <porting/README.md>
+Migrating from 5733-OPS <troubleshooting/5733OPS_MIGRATION.md>
+```
 
 ## Support
 

--- a/acscloner/README.md
+++ b/acscloner/README.md
@@ -1,5 +1,9 @@
 # ACS Clone Repo Tool
 
+```{toctree}
+:maxdepth: 1
+```
+
 The "Clone Repo" tool is a tool that allows you to clone any http or
 https-hosted RPM repository to the local Integrated File System (IFS) of the
 target IBM i system.

--- a/camel/README.md
+++ b/camel/README.md
@@ -1,5 +1,9 @@
 # Apache Camel
 
+```{toctree}
+:maxdepth: 1
+```
+
 [Apache Camel](https://camel.apache.org) is a powerful Java-based integration framework that can be used to
 integrate countless technologies, including IBM i. For a brief introduction, see this article: 
 [Integrate IBM i With Anything Using Apache Camel](https://techchannel.com/SMB/8/2021/ibm-i-apache-camel).

--- a/certbot.md
+++ b/certbot.md
@@ -1,4 +1,9 @@
 # LetsEncrypt w/Certbot
+
+```{toctree}
+:maxdepth: 1
+```
+
 Certbot can be used to get/renew LetsEncrypt certificates. Follow these instructions to install and use Certbot. 
 Certbot's web site can be found at [https://certbot.eff.org](https://certbot.eff.org).
 

--- a/conf.py
+++ b/conf.py
@@ -1,47 +1,5 @@
-# At top on conf.py (with other import statements)
-import recommonmark
-
-# See
-# https://github.com/readthedocs/recommonmark/issues/156#issuecomment-607641732
-#from recommonmark.transform import AutoStructify
-
 import os
 from docutils import nodes
-from recommonmark.transform import AutoStructify as AutoStructifyOrig
-
-class AutoStructify(AutoStructifyOrig):
-    def parse_ref(self, ref):
-        """
-        Patch AutoStructify for relative path
-        """
-        title = None
-        if len(ref.children) == 0:
-            title = ref['name'] if 'name' in ref else None
-        elif isinstance(ref.children[0], nodes.Text):
-            title = ref.children[0].astext()
-        uri = ref['refuri']
-        if uri.find('://') != -1:
-            return (title, uri, None)
-        anchor = None
-        arr = uri.split('#')
-        if len(arr) == 2:
-            anchor = arr[1]
-        if len(arr) > 2 or len(arr[0]) == 0:
-            return (title, uri, None)
-        uri = arr[0]
-
-        abspath = os.path.abspath(os.path.join(self.file_dir, uri))
-        # ** Patch
-        if uri[0] != '/': # input uri is relative path
-            abspath = '/' + os.path.relpath(abspath, self.root_dir)
-        relpath = os.path.relpath(abspath, self.root_dir)
-
-        # use url resolver
-        if self.url_resolver:
-            uri = self.url_resolver(relpath)
-        if anchor:
-            uri += '#' + anchor
-        return (title, uri, None)
 
 # Configuration file for the Sphinx documentation builder.
 #
@@ -73,7 +31,7 @@ author = 'IBM i OSS Docs Authors'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'recommonmark',
+    'myst_parser',
     'sphinx_reredirects',
 ]
 
@@ -96,7 +54,7 @@ exclude_patterns = [
     '.DS_Store',
     '.licensing',
     'requirements.txt',
-    '.venv',
+    '.venv*',
 ]
 
 master_doc = 'README'
@@ -118,12 +76,5 @@ redirects = {
     'yum/RELEASE_REPOS': "../yum/IBM_REPOS.html",
 }
 
-def setup(app):
-    app.add_config_value('recommonmark_config', {
-            'enable_auto_toc_tree': True,
-            'enable_auto_doc_ref': False, # broken in Sphinx 1.6+
-            'enable_eval_rst': True,
-            'auto_toc_tree_section': 'Contents',
-            }, True)
-    app.add_transform(AutoStructify)
-
+# Allow MyST to generate links to subheadings up to 3 deep (H3 / ###)
+myst_heading_anchors = 3

--- a/java/APP_SERVERS.md
+++ b/java/APP_SERVERS.md
@@ -1,8 +1,12 @@
 # Open Source Java Application Servers
 
+```{toctree}
+:maxdepth: 1
+```
+
 This page documents open source Java application servers. All items on this page are known to work on IBM i. 
 
-```eval_rst
+```{eval-rst}
 +--------------------------------+----------------------------------------------+---------------------------+
 |       Application Server       |                Governed By                   | IBM `Support`_ Available? |
 +================================+==============================================+===========================+

--- a/java/JAVA11_EARLY_ACCESS.md
+++ b/java/JAVA11_EARLY_ACCESS.md
@@ -1,5 +1,9 @@
 # Java 11 Early Access RPM
 
+```{toctree}
+:maxdepth: 1
+```
+
 A Java RPM is now available, via the `openjdk-11-ea` packages! Note, however,
 this is not considered generally available (GA). It is an early access package ONLY.
 

--- a/java/README.md
+++ b/java/README.md
@@ -4,5 +4,9 @@ Here you'll find information about using open source Java on IBM i.
 
 ## Contents
 
-- [Java 11](JAVA11_EARLY_ACCESS.md)
-- [Application Servers](APP_SERVERS.md)
+```{toctree}
+:maxdepth: 1
+
+Java 11 <JAVA11_EARLY_ACCESS.md>
+Application Servers <APP_SERVERS.md>
+```

--- a/kafka/KAFKA_CAMEL_DTAQ.md
+++ b/kafka/KAFKA_CAMEL_DTAQ.md
@@ -1,5 +1,8 @@
-
 # Using Db2 Triggers and Apache Camel to stream Db2 events to Kafka
+
+```{toctree}
+:maxdepth: 1
+```
 
 ## How it works
 

--- a/kafka/KAFKA_CONNECT_JDBC.md
+++ b/kafka/KAFKA_CONNECT_JDBC.md
@@ -1,5 +1,9 @@
 # Using the JDBC Source/Sink Connectors and Kafka Connect
 
+```{toctree}
+:maxdepth: 1
+```
+
 Download the JDBC Connector (Source and Sink) from Confluent Hub [confluentinc-kafka-connect-jdbc-10.2.0.zip]. Source connectors are used to read data from a database. Sink connectors are used to insert data into a database.
 
 Steps for installing the plugin came from https://docs.confluent.io/home/connect/userguide.html#connect-installing-plugins

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,5 +1,8 @@
-
 # Kafka
+
+```{toctree}
+:maxdepth: 1
+```
 
 ## Streaming data to Kafka from IBM i
 There are several approaches to streaming data from Db2 transactions to Kafka, including but not limited to:

--- a/nginx.md
+++ b/nginx.md
@@ -1,5 +1,9 @@
 # NGINX
 
+```{toctree}
+:maxdepth: 1
+```
+
 ## Summary
 
 Here you will find general information as it relates to Nginx on IBM i.  This is

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -1,4 +1,9 @@
 # Node.js usage notes
+
+```{toctree}
+:maxdepth: 1
+```
+
 All things assume you have [PATH set correctly](../troubleshooting/SETTING_PATH.md)
 
 ## Choosing which major version of Node.js to use

--- a/odbc/README.md
+++ b/odbc/README.md
@@ -10,7 +10,11 @@ the correct drivers installed.
 
 ## Contents
 
-- [Why ODBC?](why-odbc.md)
-- [Installing and configuring ODBC](installation.md)
-- [Using ODBC](using.md)
-- [Examples](examples.md)
+```{toctree}
+:maxdepth: 1
+
+Why ODBC? <why-odbc.md>
+Installing and configuring ODBC <installation.md>
+Using ODBC <using.md>
+Examples <examples.md>
+```

--- a/odbc/examples.md
+++ b/odbc/examples.md
@@ -1,5 +1,9 @@
 # Node.js Example
 
+```{toctree}
+:maxdepth: 1
+```
+
 This quick example will demonstrate development on a non-IBM i machine against
 Db2 on i, and then how you would transfer that same code to run on IBM i when
 you are ready to run in production.

--- a/odbc/installation.md
+++ b/odbc/installation.md
@@ -1,5 +1,9 @@
 # IBM i Access ODBC Installation
 
+```{toctree}
+:maxdepth: 1
+```
+
 The instructions for installing and ODBC driver and manager and the IBM i ODBC
 driver for Db2 on i will depend on what operating system you are running. Select
 your operating system below to see setup instructions for getting ODBC on your

--- a/odbc/using.md
+++ b/odbc/using.md
@@ -1,5 +1,9 @@
 # Using ODBC
 
+```{toctree}
+:maxdepth: 1
+```
+
 Now that you have the IBM i Access ODBC Driver installed on your system, you are
 ready to connect to Db2 on i.
 

--- a/odbc/why-odbc.md
+++ b/odbc/why-odbc.md
@@ -1,5 +1,9 @@
 # Why ODBC
 
+```{toctree}
+:maxdepth: 1
+```
+
 For the open-source software team, ODBC is the preferred method of connecting to
 Db2 on i. There are many resons for this, including:
 

--- a/porting/GOTCHAS.md
+++ b/porting/GOTCHAS.md
@@ -1,5 +1,9 @@
 # Gotchas When Building Software in PASE
 
+```{toctree}
+:maxdepth: 1
+```
+
 ## malloc behaves differently from many other platforms
 
 [Zero byte allocations](https://whatilearned2day.wordpress.com/2006/07/13/zero-sized-allocation-using-malloc-on-aix/)

--- a/porting/PASE-TO-AIX-LEVEL.md
+++ b/porting/PASE-TO-AIX-LEVEL.md
@@ -1,6 +1,10 @@
 # Map PASE/IBM i Version to AIX Version
 
-```eval_rst
+```{toctree}
+:maxdepth: 1
+```
+
+```{eval-rst}
 +---------------+-------------+
 | IBM i Version | AIX Version |
 +===============+=============+

--- a/porting/README.md
+++ b/porting/README.md
@@ -2,5 +2,9 @@
 
 ## Contents
 
-* [Porting Gotchas](GOTCHAS)
-* [PASE to AIX Level Mapping](PASE-TO-AIX-LEVEL)
+```{toctree}
+:maxdepth: 1
+
+Porting Gotchas <GOTCHAS>
+PASE to AIX Level Mapping <PASE-TO-AIX-LEVEL>
+```

--- a/postgresql.md
+++ b/postgresql.md
@@ -1,5 +1,9 @@
 # PostgreSQL Installation and Basic Configuration on IBM i
 
+```{toctree}
+:maxdepth: 1
+```
+
 The purpose of this document is to summarize PostgreSQL installation and basic
 configuration on IBM i. The following topics are outlined below: initial setup,
 enabling remote connections, server startup, and connecting with a client.

--- a/python/INSTALLING_PYTHON_PKGS.md
+++ b/python/INSTALLING_PYTHON_PKGS.md
@@ -1,5 +1,11 @@
 # Installing Python Packages
+
+```{toctree}
+:maxdepth: 1
+```
+
 See [Python usage notes](./README.md) for basic information.
+
 ## General Guidance
 For packages not listed in the above table, first check if it's available via
 yum. If so, it is recommended to install it through yum instead of installing

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,9 @@
 # Python usage notes
+
+```{toctree}
+:maxdepth: 1
+```
+
 All things assume you have [PATH set correctly](../troubleshooting/SETTING_PATH.md)
 
 ## Which versions are available?

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ packaging==20.4
 Pygments==2.7.4
 pyparsing==2.4.7
 pytz==2020.1
-recommonmark==0.6.0
+myst-parser==0.17.0
 requests>=2.25.1
 six==1.15.0
 snowballstemmer==2.0.0

--- a/tls/README.md
+++ b/tls/README.md
@@ -1,5 +1,9 @@
 # TLS Setup
 
+```{toctree}
+:maxdepth: 1
+```
+
 ## Best practices
 
 It is often considered best practice to not handle TLS encryption within the application (for

--- a/troubleshooting/5733OPS_MIGRATION.md
+++ b/troubleshooting/5733OPS_MIGRATION.md
@@ -1,5 +1,9 @@
 # Guide to migrating from 5733-OPS to RPMs
 
+```{toctree}
+:maxdepth: 1
+```
+
 ## Environment setup (PATH)
 
 By default, the RPM-form packages do not create symbolic links in standard,

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -1,5 +1,9 @@
 # Common Open Source Problems (and how to fix them)
 
+```{toctree}
+:maxdepth: 1
+```
+
 ## Things to always check first when troubleshooting
 
 The first step in troubleshooting is to ensure that

--- a/troubleshooting/SETTING_BASH.md
+++ b/troubleshooting/SETTING_BASH.md
@@ -1,5 +1,9 @@
 # Setting BASH as your shell
 
+```{toctree}
+:maxdepth: 1
+```
+
 ***The bash shell can (and should!) be your default shell for when you connect
 with an SSH session. SSH connections are recommended for open source tools.
 This will not affect the shell in use by non-SSH shell environments, such as

--- a/troubleshooting/SETTING_PATH.md
+++ b/troubleshooting/SETTING_PATH.md
@@ -1,5 +1,9 @@
 # Adjusting your PATH temporarily
 
+```{toctree}
+:maxdepth: 1
+```
+
 Temporarily adjust your path by running the following two commands:
 
 ```bash

--- a/yum/3RD_PARTY_REPOS.md
+++ b/yum/3RD_PARTY_REPOS.md
@@ -1,5 +1,9 @@
 # Third-party (non-IBM) repositories
 
+```{toctree}
+:maxdepth: 1
+```
+
 The repositories listed on this page are not owned, managed, or supported by
 IBM. However, the repositories have been inspected and the software
 generally seems to be built with IBM-approved conventions for existing well in

--- a/yum/IBM_REPOS.md
+++ b/yum/IBM_REPOS.md
@@ -1,5 +1,9 @@
 # IBM Repositories
 
+```{toctree}
+:maxdepth: 1
+```
+
 IBM provides a set of repositories to use with yum. Currently, this is one repo called "ibm" pointing [here](https://public.dhe.ibm.com/software/ibmi/products/pase/rpms/repo). This repo file is setup and enabled during the bootstrap
 installation, however admins are free to disable or change this file at their discretion.
 

--- a/yum/README.md
+++ b/yum/README.md
@@ -1,5 +1,9 @@
 # RPM pile for IBM i releases in standard support
 
+```{toctree}
+:maxdepth: 1
+```
+
 ## General Information
 
 Much of the open source technology available in the 5733-OPS product is now


### PR DESCRIPTION
recommonmark is abandoned in favor of MyST-Parser. See
https://github.com/readthedocs/recommonmark/issues/221 for more details.

The biggest change for us is needing to add toctree directives directly
instead of relying on AutoStructify.

With these changes, looking at the docs you should not be able to tell anything
changed.