### PR TITLE
doc: Add reportlab install info

### DIFF
--- a/python/INSTALLING_PYTHON_PKGS.md
+++ b/python/INSTALLING_PYTHON_PKGS.md
@@ -26,3 +26,24 @@ You will also need to set the following environment variables for build:
 
 If you have issues that you cannot debug, feel free to join the community channels
 documented [here](http://ibm.biz/ibmioss)!
+
+
+### reportlab
+
+```bash
+CFLAGS="-D_LINUX_SOURCE_COMPAT" pip3.9 install reportlab
+```
+
+Defining `_LINUX_SOURCE_COMPAT` disables `func_data` from being defined in `/usr/include/sys/timer.h` `func_data` is refrenced in `src/rl_addons/renderPM/libart_lgpl/art_pixbuf.h` and `timer.h` is included indirectly from `Python.h`.
+
+```c
+// /usr/include/sys/timer.h
+#ifndef  _LINUX_SOURCE_COMPAT
+#define func_data       t_union.data
+#endif
+```
+
+```c
+src/rl_addons/renderPM/libart_lgpl/art_pixbuf.h:38:41: error: expected ';', ',' or ')' before '.' token
+ typedef void (*ArtDestroyNotify) (void *func_data, void *data);
+```


### PR DESCRIPTION
pip installing reportlab with python3.9 fails building `_renderPM` extension.

```c

    In file included from /usr/include/sys/thread.h:41:0,
                     from /usr/include/sys/ptrace.h:28,
                     from /usr/include/sys/proc.h:42,
                     from /usr/include/sys/pri.h:43,
                     from /usr/include/sys/sched.h:38,
                     from /usr/include/sched.h:51,
                     from /usr/include/pthread.h:67,
                     from /QOpenSys/pkgs/include/python3.9/pythread.h:128,
                     from /QOpenSys/pkgs/include/python3.9/Python.h:131,
                     from src/rl_addons/renderPM/_renderPM.c:1:
    src/rl_addons/renderPM/libart_lgpl/art_pixbuf.h:38:41: error: expected ';', ',' or ')' before '.' token
     typedef void (*ArtDestroyNotify) (void *func_data, void *data);
                                             ^
    In file included from src/rl_addons/renderPM/libart_lgpl/libart.h:11:0,
                     from src/rl_addons/renderPM/_renderPM.c:11:
    src/rl_addons/renderPM/libart_lgpl/art_pixbuf.h:63:3: error: unknown type name 'ArtDestroyNotify'
       ArtDestroyNotify destroy;
       ^~~~~~~~~~~~~~~~
    src/rl_addons/renderPM/libart_lgpl/art_pixbuf.h:83:26: error: unknown type name 'ArtDestroyNotify'
            void *dfunc_data, ArtDestroyNotify dfunc);
                              ^~~~~~~~~~~~~~~~
    src/rl_addons/renderPM/libart_lgpl/art_pixbuf.h:87:27: error: unknown type name 'ArtDestroyNotify'
             void *dfunc_data, ArtDestroyNotify dfunc);
```

Workaround to resolve the build failure is to define `_LINUX_SOURCE_COMPAT`.