### PR TITLE
fix: nginx reverse proxy example

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -102,7 +102,7 @@ http {
     ssl_session_cache shared:SSL:50m;
     ssl_prefer_server_ciphers on;
     location / {
-      proxy_pass http://node_servers;
+      proxy_pass http://$node_servers;
     }
   }
 }


### PR DESCRIPTION
use variable instead of string literal

@ThePrez 
I believe the intention here is to refer back the `node_severs` variable right?