### PR TITLE
fix yum development tools command

### DIFF
--- a/python/INSTALLING_PYTHON_PKGS.md
+++ b/python/INSTALLING_PYTHON_PKGS.md
@@ -17,9 +17,9 @@ it using pip.
 If you must install using pip, make sure to invoke pip correctly (see
 [Python usage notes](./README.md))
 
-Also, you may need to install develompent tools, like gcc and automake, which you
+Also, you may need to install development tools, like gcc and automake, which you
 can often do a la carte (`yum install gcc automake`) or you may need to install
-the "Developer Tools" group (`yum install "Developer Tools"`). 
+the "Development Tools" group (`yum group install "Development Tools"`). 
 
 You will also need to set the following environment variables for build:
 - `OBJECT_MODE=64`


### PR DESCRIPTION
OK, I created an issue prior to creating the pull request.

I'll close out issue #141, text from #141 ...

The [Installing Python Packages](https://ibmi-oss-docs.readthedocs.io/en/latest/python/INSTALLING_PYTHON_PKGS.html) page makes reference to the command `yum install "Developer Tools"` to install the “Developer Tools” group.

The command should be `yum group install "Development Tools"`.

There are no other references to the `yum install "Developer Tools"` command in the repo.

I suggest changing the paragraph to the following ...

Also, you may need to install development tools, like gcc and automake, which you can often do a la carte (`yum install gcc automake`) or you may need to install the “Development Tools” group (`yum group install "Development Tools"`).





