### PR TITLE
Migrate RtD settings to config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,16 @@
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+sphinx:
+  configuration: conf.py
+  # Need to fix warnings before we can enable this
+  #fail_on_warning: true
+
+python:
+  install:
+    - requirements: requirements.txt

--- a/conf.py
+++ b/conf.py
@@ -74,6 +74,7 @@ html_static_path = ['_static']
 redirects = {
     'java11/JAVA11_EARLY_ACCESS': "../java/JAVA11_EARLY_ACCESS.html",
     'yum/RELEASE_REPOS': "../yum/IBM_REPOS.html",
+    'index': 'README.html',
 }
 
 # Allow MyST to generate links to subheadings up to 3 deep (H3 / ###)


### PR DESCRIPTION
Read the Docs now requires all projects to use a settings file. https://blog.readthedocs.com/migrate-configuration-v2/