### PR TITLE
Use Python 3.11 to fix RtD build issue

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3"
+    python: "3.11"
 
 sphinx:
   configuration: conf.py


### PR DESCRIPTION
Current default Python 3 is 3.12, which brings incompatibilities due to removal of distutils.

ModuleNotFoundError: No module named 'distutils'

Not ready to require Python 3.12, so for now, pin to version 3.11.