### PR TITLE
Improve offline install procedure

### DIFF
--- a/yum/README.md
+++ b/yum/README.md
@@ -85,7 +85,7 @@ is the case, refer to steps in "Offline Install Instructions (without ACS)".*
 - From a 5250 terminal run the following.
 
 ```text
-    QSH CMD('touch -C 819 /tmp/bootstrap.log; /QOpenSys/usr/bin/ksh /tmp/bootstrap.sh > /tmp/bootstrap.log 2>&1')
+    QSH CMD('exec /QOpenSys/usr/bin/ksh -c "/QOpenSys/usr/bin/ksh /tmp/bootstrap.sh > /tmp/bootstrap.log 2>&1"')
 ```
 
 - If you see message QSH005: "Command ended normally with exit status 0" in the
@@ -103,7 +103,7 @@ is the case, refer to steps in "Offline Install Instructions (without ACS)".*
 - From a 5250 terminal run the following.
 
 ```text
-    QSH CMD('touch -C 819 /tmp/bootstrap.log; /QOpenSys/usr/bin/ksh /tmp/bootstrap.sh > /tmp/bootstrap.log 2>&1')
+    QSH CMD('exec /QOpenSys/usr/bin/ksh -c "/QOpenSys/usr/bin/ksh /tmp/bootstrap.sh > /tmp/bootstrap.log 2>&1"')
 ```
 
 - If you see message QSH005: "Command ended normally with exit status 0" in the


### PR DESCRIPTION
If /QOpenSys/usr/bin is set ahead on the PATH, then the touch command will fail as it finds the PASE command instead of the QSH command. This was only done so that the QSH output redirect would not convert to EBCDIC, but we can bypass all that by executing the whole command and redirect within a PASE shell instead and we don't need the separate touch command.