### PR TITLE
Updated SETTING_PATH.md for changes to affect all users

### DIFF
--- a/troubleshooting/SETTING_PATH.md
+++ b/troubleshooting/SETTING_PATH.md
@@ -37,7 +37,7 @@ echo 'PATH=/QOpenSys/pkgs/bin:$PATH' >> $HOME/.profile
 echo 'export PATH' >> $HOME/.profile
 ```
 
-To make this change for all users, put these lines in `/QOpenSys/etc/profile`,
+To make this change for all users, put these lines in `/QOpenSys/etc/profile.local`,
 like so:
 
 ```bash
@@ -45,6 +45,14 @@ touch /QOpenSys/etc/profile
 setccsid 1208 /QOpenSys/etc/profile
 echo 'PATH=/QOpenSys/pkgs/bin:$PATH' >> /QOpenSys/etc/profile
 echo 'export PATH' >> /QOpenSys/etc/profile
+```
+
+Another way to make this change for all users that will also affect PASE programs called
+directly via QP2SHELL is to add the PASE_PATH environment variable at *SYS level. Run
+this as a *SECOFR class user:
+
+```
+ADDENVVAR ENVVAR(PASE_PATH) VALUE('/QOpenSys/pkgs/bin:/QOpenSys/usr/bin:/usr/ccs/bin:/QOpenSys/usr/bin/X11:/usr/sbin:.:/usr/bin') LEVEL(*SYS)
 ```
 
 **Need to run globally-installed Node.js modules,

--- a/troubleshooting/SETTING_PATH.md
+++ b/troubleshooting/SETTING_PATH.md
@@ -41,10 +41,10 @@ To make this change for all users, put these lines in `/QOpenSys/etc/profile.loc
 like so:
 
 ```bash
-touch /QOpenSys/etc/profile
-setccsid 1208 /QOpenSys/etc/profile
-echo 'PATH=/QOpenSys/pkgs/bin:$PATH' >> /QOpenSys/etc/profile
-echo 'export PATH' >> /QOpenSys/etc/profile
+touch /QOpenSys/etc/profile.local
+setccsid 1208 /QOpenSys/etc/profile.local
+echo 'PATH=/QOpenSys/pkgs/bin:$PATH' >> /QOpenSys/etc/profile.local
+echo 'export PATH' >> /QOpenSys/etc/profile.local
 ```
 
 Another way to make this change for all users that will also affect PASE programs called

--- a/troubleshooting/SETTING_PATH.md
+++ b/troubleshooting/SETTING_PATH.md
@@ -48,8 +48,9 @@ echo 'export PATH' >> /QOpenSys/etc/profile
 ```
 
 Another way to make this change for all users that will also affect PASE programs called
-directly via QP2SHELL is to add the PASE_PATH environment variable at *SYS level. Run
-this as a *SECOFR class user:
+directly via QP2SHELL is to add the PASE_PATH environment variable at *SYS level. You
+may want to do this in addition to the above, make test all your use cases to ensure the path
+is as desired (ie QP2TERM, QP2SHELL, and SSH). Run this as a *SECOFR class user:
 
 ```
 ADDENVVAR ENVVAR(PASE_PATH) VALUE('/QOpenSys/pkgs/bin:/QOpenSys/usr/bin:/usr/ccs/bin:/QOpenSys/usr/bin/X11:/usr/sbin:.:/usr/bin') LEVEL(*SYS)

--- a/troubleshooting/SETTING_PATH.md
+++ b/troubleshooting/SETTING_PATH.md
@@ -49,10 +49,11 @@ echo 'export PATH' >> /QOpenSys/etc/profile
 
 Another way to make this change for all users that will also affect PASE programs called
 directly via QP2SHELL is to add the PASE_PATH environment variable at *SYS level. You
-may want to do this in addition to the above, make test all your use cases to ensure the path
-is as desired (ie QP2TERM, QP2SHELL, and SSH). Run this as a *SECOFR class user:
+may want to do this in addition to the above, make sure to test all your use cases
+(eg. QP2TERM, QP2SHELL, and SSH) to ensure the path is as desired. Run this as a *SECOFR
+class user:
 
-```
+```text
 ADDENVVAR ENVVAR(PASE_PATH) VALUE('/QOpenSys/pkgs/bin:/QOpenSys/usr/bin:/usr/ccs/bin:/QOpenSys/usr/bin/X11:/usr/sbin:.:/usr/bin') LEVEL(*SYS)
 ```
 


### PR DESCRIPTION
This is just a minor update to the troubleshooting/SETTING_PATH.md file. On recent operating system releases the /QOpenSys/etc/profile should not be modified directly - local customizations should be in profile.local.

Also added instructions to adjust the system environment variable PASE_PATH as an alternative so that programs called directly via QP2SHELL will be affected.

Thanks!
Brandon